### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 |---| --- |
 | Version | ![](https://badgen.net/packagist/v/minetro/ghpage) |
 | PHP | ![](https://badgen.net/packagist/php/minetro/ghpage) |
-| License | ![](https://badgen.net/github/license/minetro/ghpage) |
+| License | ![](https://badgen.net/github/license/contributte/ghpage) |
 
 ## Documentation
 
@@ -55,7 +55,7 @@ To `deploing`, you can use **deploy** command.
 
 ## Development
 
-This package was maintain by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
@@ -64,4 +64,4 @@ This package was maintain by these authors.
 -----
 
 Consider to [support](https://contributte.org/partners.html) **contributte** development team.
-Also thank you for being used this package.
+Also thank you for using this package.


### PR DESCRIPTION
This PR updates the README to properly follow the archive style template:

## Changes Made
- Fixed license badge URL to use `contributte/ghpage` instead of `minetro/ghpage`
- Fixed grammar: "was maintain" → "was maintained"
- Fixed grammar: "for being used" → "for using"

## Notes
- The repository was already archived and needed to be unarchived to push changes
- The README already had the deprecated badge and disclaimer section
- No `.docs/` directory existed to remove
- Follows Option B template (without replacement package)